### PR TITLE
replace gtag

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -64,9 +64,32 @@ module.exports = {
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
     {
-      resolve: `gatsby-plugin-google-analytics`,
+      resolve: `gatsby-plugin-google-gtag`,
       options: {
-        trackingId: `G-XH47KLVQH4`,
+        // You can add multiple tracking ids and a pageview event will be fired for all of them.
+        trackingIds: [
+          "G-XH47KLVQH4", // Google Analytics / GA
+          "AW-CONVERSION_ID", // Google Ads / Adwords / AW
+          "DC-FLOODIGHT_ID", // Marketing Platform advertising products (Display & Video 360, Search Ads 360, and Campaign Manager)
+        ],
+        // // This object gets passed directly to the gtag config command
+        // // This config will be shared across all trackingIds
+        // gtagConfig: {
+        //   optimize_id: "OPT_CONTAINER_ID",
+        //   anonymize_ip: true,
+        //   cookie_expires: 0,
+        // },
+        // // This object is used for configuration specific to this plugin
+        // pluginConfig: {
+        //   // Puts tracking script in the head instead of the body
+        //   head: false,
+        //   // Setting this parameter is also optional
+        //   respectDNT: true,
+        //   // Avoids sending pageview hits from custom paths
+        //   exclude: ["/preview/**", "/do-not-track/me/too/"],
+        //   // Defaults to https://www.googletagmanager.com
+        //   origin: "YOUR_SELF_HOSTED_ORIGIN",
+        // },
       },
     },
     {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -69,8 +69,8 @@ module.exports = {
         // You can add multiple tracking ids and a pageview event will be fired for all of them.
         trackingIds: [
           "G-XH47KLVQH4", // Google Analytics / GA
-          "AW-CONVERSION_ID", // Google Ads / Adwords / AW
-          "DC-FLOODIGHT_ID", // Marketing Platform advertising products (Display & Video 360, Search Ads 360, and Campaign Manager)
+          // "AW-CONVERSION_ID", // Google Ads / Adwords / AW
+          // "DC-FLOODIGHT_ID", // Marketing Platform advertising products (Display & Video 360, Search Ads 360, and Campaign Manager)
         ],
         // // This object gets passed directly to the gtag config command
         // // This config will be shared across all trackingIds

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "gatsby": "^4.4.0",
         "gatsby-plugin-feed": "^4.4.0",
         "gatsby-plugin-gatsby-cloud": "^4.4.0",
-        "gatsby-plugin-google-analytics": "^4.4.0",
+        "gatsby-plugin-google-gtag": "^4.24.0",
         "gatsby-plugin-image": "^2.4.0",
         "gatsby-plugin-manifest": "^4.4.0",
         "gatsby-plugin-offline": "^5.4.0",
@@ -9066,22 +9066,32 @@
         "webpack": "*"
       }
     },
-    "node_modules/gatsby-plugin-google-analytics": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-4.4.0.tgz",
-      "integrity": "sha512-Z+CW64zo/d1rtyMz1bJ+Ao9apsWeyak5BXNc7piO+FwE7dFdWrAyHrgGmE3YltqFUY8+PS3vmpBv9qn0ZrOSGg==",
+    "node_modules/gatsby-plugin-google-gtag": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-4.24.0.tgz",
+      "integrity": "sha512-2GHzg727Xr+48kxS5+3xSc246gdQLlAk4L0vn5+KauJsP1aCGb2XpumlUQj8H81TA/BnroBc1wlW4N+k7J4I5Q==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
-        "minimatch": "3.0.4",
-        "web-vitals": "^1.1.2"
+        "minimatch": "^3.1.2"
       },
       "engines": {
         "node": ">=14.15.0"
       },
       "peerDependencies": {
         "gatsby": "^4.0.0-next",
-        "react": "^16.9.0 || ^17.0.0",
-        "react-dom": "^16.9.0 || ^17.0.0"
+        "react": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^0.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^0.0.0"
+      }
+    },
+    "node_modules/gatsby-plugin-google-gtag/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/gatsby-plugin-image": {
@@ -19319,11 +19329,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/web-vitals": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-1.1.2.tgz",
-      "integrity": "sha512-PFMKIY+bRSXlMxVAQ+m2aw9c/ioUYfDgrYot0YUa+/xa0sakubWhSDyxAKwzymvXVdF4CZI71g06W+mqhzu6ig=="
-    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -27112,14 +27117,23 @@
         "webpack-assets-manifest": "^5.0.6"
       }
     },
-    "gatsby-plugin-google-analytics": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-4.4.0.tgz",
-      "integrity": "sha512-Z+CW64zo/d1rtyMz1bJ+Ao9apsWeyak5BXNc7piO+FwE7dFdWrAyHrgGmE3YltqFUY8+PS3vmpBv9qn0ZrOSGg==",
+    "gatsby-plugin-google-gtag": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-4.24.0.tgz",
+      "integrity": "sha512-2GHzg727Xr+48kxS5+3xSc246gdQLlAk4L0vn5+KauJsP1aCGb2XpumlUQj8H81TA/BnroBc1wlW4N+k7J4I5Q==",
       "requires": {
         "@babel/runtime": "^7.15.4",
-        "minimatch": "3.0.4",
-        "web-vitals": "^1.1.2"
+        "minimatch": "^3.1.2"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "gatsby-plugin-image": {
@@ -34547,11 +34561,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
       "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw=="
-    },
-    "web-vitals": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-1.1.2.tgz",
-      "integrity": "sha512-PFMKIY+bRSXlMxVAQ+m2aw9c/ioUYfDgrYot0YUa+/xa0sakubWhSDyxAKwzymvXVdF4CZI71g06W+mqhzu6ig=="
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "gatsby": "^4.4.0",
     "gatsby-plugin-feed": "^4.4.0",
     "gatsby-plugin-gatsby-cloud": "^4.4.0",
-    "gatsby-plugin-google-analytics": "^4.4.0",
+    "gatsby-plugin-google-gtag": "^4.24.0",
     "gatsby-plugin-image": "^2.4.0",
     "gatsby-plugin-manifest": "^4.4.0",
     "gatsby-plugin-offline": "^5.4.0",


### PR DESCRIPTION
- Introduce gatsby-plugin-google-gtag and set it up for GA, replacing the old gatsby-plugin-google-analytics plugin
- Fix gtag IDs
